### PR TITLE
Fix items being placed into armor slots with Auto Block enabled

### DIFF
--- a/src/main/java/me/MnMaxon/AutoPickup/AutoBlock.java
+++ b/src/main/java/me/MnMaxon/AutoPickup/AutoBlock.java
@@ -20,33 +20,29 @@ public class AutoBlock {
     private static HashMap<Material, Short> convertDurability = new HashMap<>();
 
     public static HashMap<Integer, ItemStack> addItem(Player p, ItemStack is) {
-        if (!isSpaceAvailable(p, is)) {
-            return new HashMap<>();
-        }
-
         if (is == null) return new HashMap<>();
         Inventory pInv = p.getInventory();
-        Inventory inv = Bukkit.createInventory(p, InventoryType.PLAYER);
-        inv.setContents(pInv.getContents());
+        Inventory inv = Bukkit.createInventory(p, 36);
+        inv.setStorageContents(pInv.getStorageContents());
         HashMap<Integer, ItemStack> remaining = AutoPickupPlugin.giveItem(p, inv, is);
         if (!convertTo.containsKey(is.getType())) {
-            pInv.setContents(inv.getContents());
+            pInv.setStorageContents(inv.getStorageContents());
             p.updateInventory();
             return remaining;
         }
         if (remaining.size() == 1 && remaining.values().toArray()[0].equals(is)) return remaining;
-        ItemStack[] newCont = block(p, inv.getContents(), is.getType());
-        if (newCont != null) pInv.setContents(newCont);
-        else pInv.setContents(inv.getContents());
+        ItemStack[] newCont = block(p, inv.getStorageContents(), is.getType());
+        if (newCont != null) pInv.setStorageContents(newCont);
+        else pInv.setStorageContents(inv.getStorageContents());
         p.updateInventory();
         return remaining;
     }
 
     public static void block(Player p) {
-        ItemStack[] newConts = block(p, p.getInventory().getContents(), null);
+        ItemStack[] newConts = block(p, p.getInventory().getStorageContents(), null);
         if (newConts == null) p.sendMessage(Message.ERROR0BLOCKED_INVENTORY + "");
         else {
-            p.getInventory().setContents(newConts);
+            p.getInventory().setStorageContents(newConts);
             p.updateInventory();
             p.sendMessage(Message.SUCCESS0BLOCKED_INVENTORY + "");
         }
@@ -85,24 +81,17 @@ public class AutoBlock {
                                 conts[i] = null;
                             }
 
-                    Inventory inv = Bukkit.createInventory(null, InventoryType.PLAYER);
-//                    while (toMake > type.getMaxStackSize()) toMake -= type.getMaxStackSize();
+                    Inventory inv = Bukkit.createInventory(null, 36);
                     ItemStack toAdd = new ItemStack(convertTo);
-                    if (isSpaceAvailable(p, toAdd)) {
-                        inv.setContents(conts);
-                        toAdd.setAmount(type.getMaxStackSize());
-                        while (toMake > convertTo.getMaxStackSize()) {
-                            AutoPickupPlugin.giveItem(p, inv, toAdd);
-                            toMake -= type.getMaxStackSize();
-                        }
-                        toAdd.setAmount(toMake);
+                    inv.setStorageContents(conts);
+                    toAdd.setAmount(type.getMaxStackSize());
+                    while (toMake > convertTo.getMaxStackSize()) {
                         AutoPickupPlugin.giveItem(p, inv, toAdd);
-                        conts = inv.getContents();
-                    } else {
-                        //Only enable this when we have a way for users to disable this alert TODO: Implement this
-                        //p.playSound(p.getLocation(), Sound.BLOCK_NOTE_PLING, 1.0f, 1.0f);
-                        //p.sendTitle(ChatColor.RED + "Inventory is Full!", ChatColor.GOLD + "/fullnotify to disable", 1, 15, 5);
+                        toMake -= type.getMaxStackSize();
                     }
+                    toAdd.setAmount(toMake);
+                    AutoPickupPlugin.giveItem(p, inv, toAdd);
+                    conts = inv.getStorageContents();
                 }
         }
         if (totalChanged) return conts;
@@ -135,7 +124,7 @@ public class AutoBlock {
         boolean space = false;
         for (int i = 0; i <= 35; i++) {
             ItemStack slotItem = player.getInventory().getItem(i);
-            if (slotItem == null || ((slotItem.getType() == item.getType()) && item.getAmount() + slotItem.getAmount() <= player.getInventory().getMaxStackSize())) {
+            if (slotItem == null || ((slotItem.getType() == item.getType()) && item.getAmount() + slotItem.getAmount() <= slotItem.getMaxStackSize())) {
                 space = true;
             }
         }


### PR DESCRIPTION
This patch is another attempt at preventing items from being placed into a players armor slots. Fixes #2 

I have taken a new approach and removed the previous code that was in attempt to fix this as it should no longer be needed.

By default InventoryType.PLAYER creates an inventory of size 41 (which is the players full inventory/hotbar of 36 slots, the four armor slots, and the 1 offhand slot). I have updated this to be 36 which includes only enough slots for the inventory/hotbar for a total of 36 slots.

I also updated all calls of .getContents and .setContents() to use .getStorageContents and .setStorageContents() respectively. Which returns "the contents from the section of the inventory where items can reasonably be expected to be stored." Excludes armor and result slots.

This will prevent the code from ever iterating through the four armor slots and the one offhand slot. This should fix the issue for good this time. Or at least we can hope.