### PR TITLE
Added support for MoreFish & EvenMoreFish

### DIFF
--- a/src/main/java/com/philderbeast/autopickup/listners/MainListener.java
+++ b/src/main/java/com/philderbeast/autopickup/listners/MainListener.java
@@ -355,6 +355,11 @@ public class MainListener implements Listener
             && e.getCaught() instanceof Item)
         {
             Item item = (Item)e.getCaught();
+            // Doesn't handle drops for fish that have item meta (i.e. morefish/evenmorefish fish)
+            if ( ! item.getItemStack().hasItemMeta())
+            {
+                return;
+            }
             Collection < ItemStack > newDrops = e.getPlayer().getInventory().addItem(item.getItemStack()).values();
 
             if ( ! newDrops.isEmpty())


### PR DESCRIPTION
If a fish is being given meta, it's highly likely the plugin giving it meta doesn't want interrupting, so the plugin has been modified to not operate on fish with meta.